### PR TITLE
Added option to show for all NPCs, regardless of listed names.

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPConfig.java
+++ b/src/main/java/com/monsterhp/MonsterHPConfig.java
@@ -64,7 +64,17 @@ public interface MonsterHPConfig extends Config
 	{
 		return "";
 	}
-
+	@ConfigItem(
+			position = 1,
+			keyName = "npcShowAll",
+			name = "Show All",
+			description = "Show for all NPCs",
+			section = hp_settings
+	)
+	default boolean npcShowAll()
+	{
+		return true;
+	}
 	@Range(
 		max = 300
 	)

--- a/src/main/java/com/monsterhp/MonsterHPPlugin.java
+++ b/src/main/java/com/monsterhp/MonsterHPPlugin.java
@@ -50,6 +50,8 @@ public class MonsterHPPlugin extends Plugin
 
 	private List<String> selectedNPCs = new ArrayList<>();
 
+	private boolean npcShowAll = true;
+
 	private HashMap<Integer, WorldPoint> npcLocations = new HashMap<>();
 
 	@Provides
@@ -62,6 +64,7 @@ public class MonsterHPPlugin extends Plugin
 	{
 		overlayManager.add(monsterhpoverlay);
 		selectedNPCs = getSelectedNPCs();
+		this.npcShowAll =  config.npcShowAll();
 		rebuildAllNpcs();
 	}
 
@@ -80,10 +83,7 @@ public class MonsterHPPlugin extends Plugin
 		final String npcName = npc.getName();
 		final int npcId = npc.getId();
 
-		if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
-		{
-			return;
-		}
+		if (checkNPCName(npcName)) return;
 
 
 		wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
@@ -134,11 +134,8 @@ public class MonsterHPPlugin extends Plugin
 		for (NPC npc : client.getNpcs())
 		{
 			final String npcName = npc.getName();
-
-			if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
-			{
-				continue;
-			}
+			// refactored npc name check to its own method
+			if (checkNPCName(npcName)) continue;
 
 			final WanderingNPC wnpc = wanderingNPCs.get(npc.getIndex());
 
@@ -178,10 +175,25 @@ public class MonsterHPPlugin extends Plugin
 		}
 	}
 
+	private boolean checkNPCName(String npcName) {
+		if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
+		{
+			// only care about names if we are not applying to all NPCs
+			return !this.npcShowAll;
+		}
+		return false;
+	}
+
 	@Subscribe
 	public void onConfigChanged(ConfigChanged configChanged)
 	{
 		selectedNPCs = getSelectedNPCs();
+		/* update npc show all setting on every config change.
+		 * Definitely a better way to do this, but not too familiar with RL api/plugin coding.
+		 * So it will have to do for now...
+		 */
+
+		this.npcShowAll =  config.npcShowAll();
 		rebuildAllNpcs();
 	}
 
@@ -211,11 +223,8 @@ public class MonsterHPPlugin extends Plugin
 		for (NPC npc : client.getNpcs())
 		{
 			final String npcName = npc.getName();
-
-			if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
-			{
-				continue;
-			}
+			// refactored npc name check to its own method
+			if (checkNPCName(npcName)) continue;
 
 			wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
 			npcLocations.put(npc.getIndex(), npc.getWorldLocation());


### PR DESCRIPTION
I found it really annoying to have to add every NPC I wanted displayed to a list, so I added an option to display MonsterHP for all monsters, regardless of the contents of the npc names list. 
Also did some minor refactoring on npc list check logic since it was repeatedly used in multiple places. I extracted the logic to its own function. 

Hopefully you will approve this and submit it soon, would really love to be able to use this plugin for all NPCs. Thanks!