### PR TITLE
Add option to always round up Monster HP percentage.

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPConfig.java
+++ b/src/main/java/com/monsterhp/MonsterHPConfig.java
@@ -176,6 +176,18 @@ public interface MonsterHPConfig extends Config
 
 	@ConfigItem(
 		position = 11,
+		keyName = "roundUp",
+		name = "Always round up",
+		description = "Force rounding up. Useful for bosses that change phase after breaching HP percentage threshold.",
+		section = hp_settings
+	)
+	default boolean roundUp()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 11,
 		keyName = "customFont",
 		name = "Enable custom fonts",
 		description = "Enabling this setting makes it possible to use the custom font from the box below this",

--- a/src/main/java/com/monsterhp/MonsterHPOverlay.java
+++ b/src/main/java/com/monsterhp/MonsterHPOverlay.java
@@ -5,6 +5,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import javax.inject.Inject;
@@ -35,6 +36,10 @@ public class MonsterHPOverlay extends Overlay
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
 		this.config = config;
+		if(config.roundUp())
+		{
+			format.setRoundingMode(RoundingMode.UP);
+		}
 	}
 
 	protected void handleFont(Graphics2D graphics)


### PR DESCRIPTION
Useful for bosses that change phase at certain Hp%, 
e.g.
Akkha - have to kill shadow every 20%
Tumekens Warden - skull phase every 20%