### PR TITLE
Fix #4

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPPlugin.java
+++ b/src/main/java/com/monsterhp/MonsterHPPlugin.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -187,14 +188,12 @@ public class MonsterHPPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged configChanged)
 	{
-		selectedNPCs = getSelectedNPCs();
-		/* update npc show all setting on every config change.
-		 * Definitely a better way to do this, but not too familiar with RL api/plugin coding.
-		 * So it will have to do for now...
-		 */
+		if (Objects.equals(configChanged.getGroup(), "MonsterHP") && (Objects.equals(configChanged.getKey(), "npcShowAll") || Objects.equals(configChanged.getKey(), "npcToShowHp"))) {
+			selectedNPCs = getSelectedNPCs();
 
-		this.npcShowAll =  config.npcShowAll();
-		rebuildAllNpcs();
+			this.npcShowAll = config.npcShowAll();
+			rebuildAllNpcs();
+		}
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION
This PR fixes issue #4 

Hi, I'm the developer of `Dude, Where's My Stuff?`, this is hanging around in my issues, so I thought I'd explain what's happening here and put in a fix.

My plugin persists the user's inventory data in their runelite config and it does this every tick (not ideal, I'll be changing it in the future). Every time any part of the runelite config updates, you are refreshing your plugin's data, which means that the counter gets reset.

I've fixed this by putting a check in your `onConfigChanged` to make sure that the config change is one that you actually care about :)