### PR TITLE
Added an option to show numeric health for monsters instead of percentage

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPConfig.java
+++ b/src/main/java/com/monsterhp/MonsterHPConfig.java
@@ -1,6 +1,7 @@
 package com.monsterhp;
 
 import java.awt.Color;
+
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -8,233 +9,228 @@ import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
 
 @ConfigGroup("MonsterHP")
-public interface MonsterHPConfig extends Config
-{
-	enum FontStyle
-	{
-		BOLD("Bold"),
-		ITALICS("Italics"),
-		BOLD_ITALICS("Bold and italics"),
-		DEFAULT("Default");
+public interface MonsterHPConfig extends Config {
+    enum FontStyle {
+        BOLD("Bold"),
+        ITALICS("Italics"),
+        BOLD_ITALICS("Bold and italics"),
+        DEFAULT("Default");
 
-		String name;
+        String name;
 
-		FontStyle(String name)
-		{
-			this.name = name;
-		}
+        FontStyle(String name) {
+            this.name = name;
+        }
 
-		public String getName()
-		{
-			return name;
-		}
-	}
-	@ConfigSection(
-		name = "hp settings",
-		description = "Settings relating to hp",
-		position = 1
-	)
-	String hp_settings = "hp_settings";
+        public String getName() {
+            return name;
+        }
+    }
 
-	@ConfigSection(
-		name = "font settings",
-		description = "Settings relating to fonts",
-		position = 2
-	)
-	String font_settings = "font_settings";
-	@ConfigItem(
-		position = 0,
-		keyName = "showOverlay",
-		name = "Show HP over chosen NPCs",
-		description = "Configures whether or not to have the HP shown over the chosen NPCs"
-	)
-	default boolean showOverlay()
-	{
-		return true;
-	}
+    @ConfigSection(
+            name = "hp settings",
+            description = "Settings relating to hp",
+            position = 1
+    )
+    String hp_settings = "hp_settings";
 
-	@ConfigItem(
-		position = 1,
-		keyName = "npcToShowHp",
-		name = "NPC Names",
-		description = "Enter names of NPCs where you wish to use this plugin",
-		section = hp_settings
-	)
-	default String npcToShowHp()
-	{
-		return "";
-	}
-	@ConfigItem(
-		position = 2,
-		keyName = "npcShowAll",
-		name = "Show All",
-		description = "Show for all NPCs",
-		section = hp_settings
-	)
-	default boolean npcShowAll()
-	{
-		return false;
-	}
-	@Range(
-		max = 300
-	)
-	@ConfigItem(
-		position = 3,
-		keyName = "normalHPColor",
-		name = "Default hp overlay color",
-		description = "Choose the color to be used on the hp",
-		section = hp_settings
-	)
-	default Color normalHPColor()
-	{
-		return Color.GREEN;
-	}
+    @ConfigSection(
+            name = "font settings",
+            description = "Settings relating to fonts",
+            position = 2
+    )
+    String font_settings = "font_settings";
 
-	@ConfigItem(
-		position = 4,
-		keyName = "useLowHP",
-		name = "Use low HP threshold",
-		description = "Configures whether or not you wish to use a 2nd color when the monster hp hits below the low hp threshold",
-		section = hp_settings
-	)
-	default boolean useLowHP()
-	{
-		return true;
-	}
+    @ConfigItem(
+            position = 0,
+            keyName = "showOverlay",
+            name = "Show HP over chosen NPCs",
+            description = "Configures whether or not to have the HP shown over the chosen NPCs"
+    )
+    default boolean showOverlay() {
+        return true;
+    }
 
-	@ConfigItem(
-		position = 5,
-		keyName = "lowHPThreshold",
-		name = "Low HP threshold",
-		description = "Used to set the low HP threshold",
-		section = hp_settings
-	)
-	default int lowHPThreshold()
-	{
-		return 25;
-	}
+    @ConfigItem(
+            position = 1,
+            keyName = "npcToShowHp",
+            name = "NPC Names",
+            description = "Enter names of NPCs where you wish to use this plugin",
+            section = hp_settings
+    )
+    default String npcToShowHp() {
+        return "";
+    }
 
-	@ConfigItem(
-		position = 6,
-		keyName = "lowHPColor",
-		name = "Overlay color Low HP",
-		description = "Choose the color to be used when the hp of the npc is below the chosen hp threshold",
-		section = hp_settings
-	)
-	default Color lowHPColor()
-	{
-		return Color.RED;
-	}
+    @ConfigItem(
+            position = 2,
+            keyName = "npcShowAll",
+            name = "Show All",
+            description = "Show for all NPCs",
+            section = hp_settings
+    )
+    default boolean npcShowAll() {
+        return false;
+    }
 
-	@ConfigItem(
-		position = 7,
-		keyName = "aboveHPBar",
-		name = "Above HP bar",
-		description = "Hp above the monsters hp bar, otherwise the Hp is show on the body of the NPC",
-		section = hp_settings
-	)
-	default boolean aboveHPBar()
-	{
-		return true;
-	}
+    @Range(
+            max = 300
+    )
+    @ConfigItem(
+            position = 3,
+            keyName = "normalHPColor",
+            name = "Default hp overlay color",
+            description = "Choose the color to be used on the hp",
+            section = hp_settings
+    )
+    default Color normalHPColor() {
+        return Color.GREEN;
+    }
 
-	@ConfigItem(
-		position = 8,
-		keyName = "HPHeight",
-		name = "Height of the HP",
-		description = "Change the vertical offset of the HP above the npc body or the HP bar",
-		section = hp_settings
-	)
-	default int HPHeight()
-	{
-		return 25;
-	}
+    @ConfigItem(
+            position = 4,
+            keyName = "useLowHP",
+            name = "Use low HP threshold",
+            description = "Configures whether or not you wish to use a 2nd color when the monster hp hits below the low hp threshold",
+            section = hp_settings
+    )
+    default boolean useLowHP() {
+        return true;
+    }
 
-	@ConfigItem(
-		position = 9,
-		keyName = "hideDeath",
-		name = "Hide hp on death",
-		description = "Hides the hp when the npc dies. Works nicely with the entity hider: Hide Dead NPCs option",
-		section = hp_settings
-	)
-	default boolean hideDeath()
-	{
-		return false;
-	}
+    @ConfigItem(
+            position = 5,
+            keyName = "lowHPThreshold",
+            name = "Low HP threshold",
+            description = "Used to set the low HP threshold",
+            section = hp_settings
+    )
+    default int lowHPThreshold() {
+        return 25;
+    }
 
-	@ConfigItem(
-		position = 10,
-		keyName = "stackHp",
-		name = "Stack monster HP",
-		description = "Stacks the HP numbers on top of each other if multiple npc's are on the same tile",
-		section = hp_settings
-	)
-	default boolean stackHp()
-	{
-		return false;
-	}
+    @ConfigItem(
+            position = 6,
+            keyName = "lowHPColor",
+            name = "Overlay color Low HP",
+            description = "Choose the color to be used when the hp of the npc is below the chosen hp threshold",
+            section = hp_settings
+    )
+    default Color lowHPColor() {
+        return Color.RED;
+    }
 
-	@Range(
-			min = 0,
-			max = 2
-	)
-	@ConfigItem(
-			position = 11,
-			keyName = "decimalHp",
-			name = "Amount of decimals",
-			description = "Show 0-2 decimals of precision, e.g. 13.33 instead of 13.",
-			section = hp_settings
-	)
-	default int decimalHp()
-	{
-		return 0;
-	}
+    @ConfigItem(
+            position = 7,
+            keyName = "aboveHPBar",
+            name = "Above HP bar",
+            description = "Hp above the monsters hp bar, otherwise the Hp is show on the body of the NPC",
+            section = hp_settings
+    )
+    default boolean aboveHPBar() {
+        return true;
+    }
 
-	@ConfigItem(
-		position = 11,
-		keyName = "customFont",
-		name = "Enable custom fonts",
-		description = "Enabling this setting makes it possible to use the custom font from the box below this",
-		section = font_settings
-	)
-	default boolean customFont()
-	{
-		return true;
-	}
+    @ConfigItem(
+            position = 8,
+            keyName = "HPHeight",
+            name = "Height of the HP",
+            description = "Change the vertical offset of the HP above the npc body or the HP bar",
+            section = hp_settings
+    )
+    default int HPHeight() {
+        return 50;
+    }
 
-	@ConfigItem(
-		position = 12,
-		keyName = "fontName",
-		name = "Font",
-		description = "Name of the font to use for the hp shown. Leave blank to use RuneLite setting.",
-		section = font_settings
-	)
-	default String fontName()
-	{
-		return "roboto";
-	}
+    @ConfigItem(
+            position = 9,
+            keyName = "hideDeath",
+            name = "Hide hp on death",
+            description = "Hides the hp when the npc dies. Works nicely with the entity hider: Hide Dead NPCs option",
+            section = hp_settings
+    )
+    default boolean hideDeath() {
+        return false;
+    }
 
-	@ConfigItem(
-		position = 13,
-		keyName = "fontStyle",
-		name = "Font style",
-		description = "Style of the font to use for the hp shown. Only works with custom font.",
-		section = font_settings
-	)
-	default FontStyle fontStyle()
-	{
-		return FontStyle.DEFAULT;
-	}
+    @ConfigItem(
+            position = 10,
+            keyName = "stackHp",
+            name = "Stack monster HP",
+            description = "Stacks the HP numbers on top of each other if multiple npc's are on the same tile",
+            section = hp_settings
+    )
+    default boolean stackHp() {
+        return false;
+    }
 
-	@ConfigItem(
-		position = 14,
-		keyName = "fontSize",
-		name = "Font size",
-		description = "Size of the font to use for XP drops. Only works with custom font.",
-		section = font_settings
-	)
-	default int fontSize()
-	{
-		return 15;
-	}
+    @Range(
+            min = 0,
+            max = 2
+    )
+    @ConfigItem(
+            position = 11,
+            keyName = "decimalHp",
+            name = "Amount of decimals",
+            description = "Show 0-2 decimals of precision, e.g. 13.33 instead of 13.",
+            section = hp_settings
+    )
+    default int decimalHp() {
+        return 0;
+    }
+
+    @ConfigItem(
+            position = 11,
+            keyName = "customFont",
+            name = "Enable custom fonts",
+            description = "Enabling this setting makes it possible to use the custom font from the box below this",
+            section = font_settings
+    )
+    default boolean customFont() {
+        return true;
+    }
+
+    @ConfigItem(
+            position = 12,
+            keyName = "fontName",
+            name = "Font",
+            description = "Name of the font to use for the hp shown. Leave blank to use RuneLite setting.",
+            section = font_settings
+    )
+    default String fontName() {
+        return "roboto";
+    }
+
+    @ConfigItem(
+            position = 13,
+            keyName = "fontStyle",
+            name = "Font style",
+            description = "Style of the font to use for the hp shown. Only works with custom font.",
+            section = font_settings
+    )
+    default FontStyle fontStyle() {
+        return FontStyle.DEFAULT;
+    }
+
+    @ConfigItem(
+            position = 14,
+            keyName = "fontSize",
+            name = "Font size",
+            description = "Size of the font to use for XP drops. Only works with custom font.",
+            section = font_settings
+    )
+    default int fontSize() {
+        return 15;
+    }
+
+    @ConfigItem(
+            position = 15,
+            keyName = "numericHealth",
+            name = "Numeric Health",
+            description = "Show the numeric health of the monster instead of precentage.",
+            section = hp_settings
+    )
+    default boolean numericHealth() {
+        return false;
+    }
 }

--- a/src/main/java/com/monsterhp/MonsterHPOverlay.java
+++ b/src/main/java/com/monsterhp/MonsterHPOverlay.java
@@ -8,176 +8,180 @@ import java.awt.RenderingHints;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import javax.inject.Inject;
+
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Point;
+import net.runelite.client.game.NPCManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-public class MonsterHPOverlay extends Overlay
-{
-	private final MonsterHPPlugin plugin;
-	private final MonsterHPConfig config;
+@Slf4j
+public class MonsterHPOverlay extends Overlay {
+    private final MonsterHPPlugin plugin;
+    private final MonsterHPConfig config;
 
-	protected String lastFont = "";
-	protected int lastFontSize = 0;
-	protected boolean useRunescapeFont = true;
-	protected MonsterHPConfig.FontStyle lastFontStyle = MonsterHPConfig.FontStyle.DEFAULT;
-	protected Font font = null;
+    private NPCManager npcManager;
+    protected String lastFont = "";
+    protected int lastFontSize = 0;
+    protected boolean useRunescapeFont = true;
+    protected MonsterHPConfig.FontStyle lastFontStyle = MonsterHPConfig.FontStyle.DEFAULT;
+    protected Font font = null;
 
-	NumberFormat format = new DecimalFormat("#");
-	NumberFormat oneDecimalFormat = new DecimalFormat("#.#");
-	NumberFormat twoDecimalFormat = new DecimalFormat("#.##");
+    NumberFormat format = new DecimalFormat("#");
+    NumberFormat oneDecimalFormat = new DecimalFormat("#.#");
+    NumberFormat twoDecimalFormat = new DecimalFormat("#.##");
 
-	@Inject
-	MonsterHPOverlay(MonsterHPPlugin plugin, MonsterHPConfig config)
-	{
-		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_SCENE);
-		this.plugin = plugin;
-		this.config = config;
-	}
+    @Inject
+    MonsterHPOverlay(MonsterHPPlugin plugin, MonsterHPConfig config, NPCManager npcManager) {
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+        this.plugin = plugin;
+        this.config = config;
+        this.npcManager = npcManager;
+    }
 
-	protected void handleFont(Graphics2D graphics)
-	{
-		if(font != null)
-		{
-			graphics.setFont(font);
-			if(useRunescapeFont)
-			{
-				graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-			}
-		}
-	}
+    protected void handleFont(Graphics2D graphics) {
+        if (font != null) {
+            graphics.setFont(font);
+            if (useRunescapeFont) {
+                graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+            }
+        }
+    }
 
-	@Override
-	public Dimension render(Graphics2D graphics)
-	{
-		updateFont();
-		handleFont(graphics);
-		if (config.showOverlay())
-		{
-			plugin.getWanderingNPCs().forEach((id, npc) -> renderTimer(npc, graphics));
-		}
-		return null;
-	}
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        updateFont();
+        handleFont(graphics);
+        if (config.showOverlay()) {
+            plugin.getWanderingNPCs().forEach((id, npc) -> renderTimer(npc, graphics));
+        }
+        return null;
+    }
 
-	private void renderTimer(final WanderingNPC npc, final Graphics2D graphics)
-	{
-		if(npc.isDead()) {
-			return;
-		}
+    private String getCurrentHpString(WanderingNPC npc) {
+        String currentHPString;
+        if (config.numericHealth()) {
+            currentHPString = String.valueOf(npc.getCurrentHp());
+        } else {
+            switch (config.decimalHp()) {
+                case 1:
+                    currentHPString = String.valueOf(oneDecimalFormat.format(npc.getHealthRatio()));
+                    break;
+                case 2:
+                    currentHPString = String.valueOf(twoDecimalFormat.format(npc.getHealthRatio()));
+                    break;
+                default:
+                    currentHPString = String.valueOf(format.format(npc.getHealthRatio()));
+                    break;
+            }
+        }
+        return currentHPString;
+    }
 
-		Color timerColor = config.normalHPColor();
 
-		if (config.useLowHP() && npc.getCurrentHp() < config.lowHPThreshold())
-		{
-			timerColor = config.lowHPColor();
-		}
+    private void renderTimer(final WanderingNPC npc, final Graphics2D graphics) {
+        if (npc.isDead()) {
+            return;
+        }
+        Color timerColor = config.normalHPColor();
 
-		String currentHPString;
-		switch (config.decimalHp()) {
-			case 1:
-				currentHPString = String.valueOf(oneDecimalFormat.format(npc.getCurrentHp()));
-				break;
-			case 2:
-				currentHPString = String.valueOf(twoDecimalFormat.format(npc.getCurrentHp()));
-				break;
-			default:
-				currentHPString = String.valueOf(format.format(npc.getCurrentHp()));
-				break;
-		}
-		Point canvasPoint;
-		if (config.aboveHPBar())
-		{
-			canvasPoint = npc.getNpc().getCanvasTextLocation(graphics, currentHPString, npc.getNpc().getLogicalHeight() + config.HPHeight());
-		}
-		else
-		{
-			canvasPoint = npc.getNpc().getCanvasTextLocation(graphics, currentHPString, config.HPHeight());
-		}
 
-		if(canvasPoint == null) {
-			return;
-		}
+        if (config.numericHealth()) {
+            try {
+                boolean isHealthBelowThreshold = npc.getHealthRatio() < config.lowHPThreshold();
+                //Use the current health ratio and round it according to monsters max hp
+                double numericHealth = Math.round((npc.getHealthRatio() / 100) * npcManager.getHealth(npc.getId()));
+                npc.setCurrentHp(numericHealth);
+                if (config.useLowHP() && isHealthBelowThreshold) {
+                    timerColor = config.lowHPColor();
+                }
+            } catch (Exception e) {
+                //todo: this will happend mostly because some wandering npcs have no real health and are not attackable, need to fix this
+                log.error("there was an error:" + e);
+            }
+        } else {
+            if (config.useLowHP() && npc.getHealthRatio() < config.lowHPThreshold()) {
+                timerColor = config.lowHPColor();
+            }
+        }
+        String currentHPString = getCurrentHpString(npc);
 
-		if (config.stackHp())
-		{
-			int offSet = (int) (npc.getOffset() * config.fontSize() * 0.85);
-			Point stackOffset = new Point(canvasPoint.getX(), canvasPoint.getY() + offSet);
-			OverlayUtil.renderTextLocation(graphics, stackOffset, currentHPString, timerColor);
-		}
-		else
-		{
-			OverlayUtil.renderTextLocation(graphics, canvasPoint, currentHPString, timerColor);
-		}
-	}
-	private void updateFont()
-	{
-		//only perform anything within this function if any settings related to the font have changed
-		if(!lastFont.equals(config.fontName()) || lastFontSize != config.fontSize() || lastFontStyle != config.fontStyle())
-		{
-			if(config.customFont()){
-				lastFont = config.fontName();
-			}
-			lastFontSize = config.fontSize();
-			lastFontStyle = config.fontStyle();
+        Point canvasPoint;
+        if (config.aboveHPBar()) {
+            canvasPoint = npc.getNpc().getCanvasTextLocation(graphics, currentHPString, npc.getNpc().getLogicalHeight() + config.HPHeight());
+        } else {
+            canvasPoint = npc.getNpc().getCanvasTextLocation(graphics, currentHPString, config.HPHeight());
+        }
 
-			//use runescape font as default
-			if (config.fontName().equals("") || config.customFont() == false)
-			{
-				if (config.fontSize() < 16)
-				{
-					font = FontManager.getRunescapeSmallFont();
-				}
-				else if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD || config.fontStyle() == MonsterHPConfig.FontStyle.BOLD_ITALICS)
-				{
-					font = FontManager.getRunescapeBoldFont();
-				}
-				else
-				{
-					font = FontManager.getRunescapeFont();
-				}
+        if (canvasPoint == null) {
+            return;
+        }
 
-				if (config.fontSize() > 16)
-				{
-					font = font.deriveFont((float)config.fontSize());
-				}
+        if (config.stackHp()) {
+            int offSet = (int) (npc.getOffset() * config.fontSize() * 0.85);
+            Point stackOffset = new Point(canvasPoint.getX(), canvasPoint.getY() + offSet);
+            OverlayUtil.renderTextLocation(graphics, stackOffset, currentHPString, timerColor);
+        } else {
+            OverlayUtil.renderTextLocation(graphics, canvasPoint, currentHPString, timerColor);
+        }
+    }
 
-				if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD)
-				{
-					font = font.deriveFont(Font.BOLD);
-				}
-				if (config.fontStyle() == MonsterHPConfig.FontStyle.ITALICS)
-				{
-					font = font.deriveFont(Font.ITALIC);
-				}
-				if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD_ITALICS)
-				{
-					font = font.deriveFont(Font.ITALIC | Font.BOLD);
-				}
+    private void updateFont() {
+        //only perform anything within this function if any settings related to the font have changed
+        if (!lastFont.equals(config.fontName()) || lastFontSize != config.fontSize() || lastFontStyle != config.fontStyle()) {
+            if (config.customFont()) {
+                lastFont = config.fontName();
+            }
+            lastFontSize = config.fontSize();
+            lastFontStyle = config.fontStyle();
 
-				useRunescapeFont = true;
-				return;
-			}
+            //use runescape font as default
+            if (config.fontName().equals("") || config.customFont() == false) {
+                if (config.fontSize() < 16) {
+                    font = FontManager.getRunescapeSmallFont();
+                } else if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD || config.fontStyle() == MonsterHPConfig.FontStyle.BOLD_ITALICS) {
+                    font = FontManager.getRunescapeBoldFont();
+                } else {
+                    font = FontManager.getRunescapeFont();
+                }
 
-			int style = Font.PLAIN;
-			switch (config.fontStyle())
-			{
-				case BOLD:
-					style = Font.BOLD;
-					break;
-				case ITALICS:
-					style = Font.ITALIC;
-					break;
-				case BOLD_ITALICS:
-					style = Font.BOLD | Font.ITALIC;
-					break;
-			}
+                if (config.fontSize() > 16) {
+                    font = font.deriveFont((float) config.fontSize());
+                }
 
-			font = new Font(config.fontName(), style, config.fontSize());
-			useRunescapeFont = false;
-		}
-	}
+                if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD) {
+                    font = font.deriveFont(Font.BOLD);
+                }
+                if (config.fontStyle() == MonsterHPConfig.FontStyle.ITALICS) {
+                    font = font.deriveFont(Font.ITALIC);
+                }
+                if (config.fontStyle() == MonsterHPConfig.FontStyle.BOLD_ITALICS) {
+                    font = font.deriveFont(Font.ITALIC | Font.BOLD);
+                }
+
+                useRunescapeFont = true;
+                return;
+            }
+
+            int style = Font.PLAIN;
+            switch (config.fontStyle()) {
+                case BOLD:
+                    style = Font.BOLD;
+                    break;
+                case ITALICS:
+                    style = Font.ITALIC;
+                    break;
+                case BOLD_ITALICS:
+                    style = Font.BOLD | Font.ITALIC;
+                    break;
+            }
+
+            font = new Font(config.fontName(), style, config.fontSize());
+            useRunescapeFont = false;
+        }
+    }
 }

--- a/src/main/java/com/monsterhp/MonsterHPOverlay.java
+++ b/src/main/java/com/monsterhp/MonsterHPOverlay.java
@@ -65,7 +65,7 @@ public class MonsterHPOverlay extends Overlay {
     private String getCurrentHpString(WanderingNPC npc) {
         String currentHPString;
         if (config.numericHealth()) {
-            currentHPString = String.valueOf(npc.getCurrentHp());
+            currentHPString = String.valueOf((int) npc.getCurrentHp());
         } else {
             switch (config.decimalHp()) {
                 case 1:

--- a/src/main/java/com/monsterhp/MonsterHPPlugin.java
+++ b/src/main/java/com/monsterhp/MonsterHPPlugin.java
@@ -2,6 +2,7 @@ package com.monsterhp;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Inject;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -30,203 +32,175 @@ import net.runelite.client.util.Text;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Monster HP Percentage"
+        name = "Monster HP Percentage"
 )
-public class MonsterHPPlugin extends Plugin
-{
-	@Inject
-	private Client client;
+public class MonsterHPPlugin extends Plugin {
+    @Inject
+    private Client client;
 
-	@Inject
-	private MonsterHPConfig config;
+    @Inject
+    private MonsterHPConfig config;
 
-	@Inject
-	private OverlayManager overlayManager;
-
-	@Inject
-	private MonsterHPOverlay monsterhpoverlay;
-
-	@Getter(AccessLevel.PACKAGE)
-	private final Map<Integer, WanderingNPC> wanderingNPCs = new HashMap<>();
-
-	private List<String> selectedNPCs = new ArrayList<>();
-
-	private boolean npcShowAll = true;
-
-	private HashMap<Integer, WorldPoint> npcLocations = new HashMap<>();
-
-	@Provides
-	MonsterHPConfig getConfig(ConfigManager configManager)
-	{
-		return configManager.getConfig(MonsterHPConfig.class);
-	}
-	@Override
-	protected void startUp() throws Exception
-	{
-		overlayManager.add(monsterhpoverlay);
-		selectedNPCs = getSelectedNPCs();
-		this.npcShowAll =  config.npcShowAll();
-		rebuildAllNpcs();
-	}
-
-	@Override
-	protected void shutDown() throws Exception
-	{
-		overlayManager.remove(monsterhpoverlay);
-		wanderingNPCs.clear();
-		npcLocations.clear();
-	}
-
-	@Subscribe
-	public void onNpcSpawned(NpcSpawned npcSpawned)
-	{
-		final NPC npc = npcSpawned.getNpc();
-		final String npcName = npc.getName();
-		final int npcId = npc.getId();
-
-		if (checkNPCName(npcName)) return;
+    @Inject
+    private OverlayManager overlayManager;
 
 
-		wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
-		npcLocations.put(npc.getIndex(), npc.getWorldLocation());
-	}
+    @Inject
+    private MonsterHPOverlay monsterhpoverlay;
 
-	@Subscribe
-	public void onNpcDespawned(NpcDespawned npcDespawned)
-	{
-		final NPC npc = npcDespawned.getNpc();
-		final String npcName = npc.getName();
+    @Getter(AccessLevel.PACKAGE)
+    private final Map<Integer, WanderingNPC> wanderingNPCs = new HashMap<>();
 
-		if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
-		{
-			return;
-		}
+    private List<String> selectedNPCs = new ArrayList<>();
 
-		wanderingNPCs.remove(npc.getIndex());
-		npcLocations.remove(npc.getIndex());
-	}
+    private boolean npcShowAll = true;
 
-	@Subscribe
-	public void onGameStateChanged(GameStateChanged gameStateChanged)
-	{
-		if (gameStateChanged.getGameState() == GameState.LOGIN_SCREEN ||
-			gameStateChanged.getGameState() == GameState.HOPPING)
-		{
-			wanderingNPCs.clear();
-			npcLocations.clear();
-		}
-	}
+    private HashMap<Integer, WorldPoint> npcLocations = new HashMap<>();
 
-	@Subscribe
-	public void onGameTick(GameTick event)
-	{
-		HashMap<WorldPoint, Integer> locationCount = new HashMap<>();
-		for (WorldPoint location : npcLocations.values())
-		{
-			if (locationCount.containsKey(location))
-			{
-				locationCount.put(location, locationCount.get(location) + 1);
-			}
-			else
-			{
-				locationCount.put(location, 1);
-			}
-		}
-		for (NPC npc : client.getNpcs())
-		{
-			final String npcName = npc.getName();
-			// refactored npc name check to its own method
-			if (checkNPCName(npcName)) continue;
+    @Provides
+    MonsterHPConfig getConfig(ConfigManager configManager) {
+        return configManager.getConfig(MonsterHPConfig.class);
+    }
 
-			final WanderingNPC wnpc = wanderingNPCs.get(npc.getIndex());
+    @Override
+    protected void startUp() throws Exception {
+        overlayManager.add(monsterhpoverlay);
+        selectedNPCs = getSelectedNPCs();
+        this.npcShowAll = config.npcShowAll();
+        rebuildAllNpcs();
+    }
 
-			if (wnpc == null)
-			{
-				continue;
-			}
+    @Override
+    protected void shutDown() throws Exception {
+        overlayManager.remove(monsterhpoverlay);
+        wanderingNPCs.clear();
+        npcLocations.clear();
+    }
 
-			if(config.showOverlay())
-			{
-				double monsterHP = ((double) npc.getHealthRatio() / (double) npc.getHealthScale() * 100);
-				if (!npc.isDead())
-				{
-					if((npc.getHealthRatio()/npc.getHealthScale() != 1))
-					{
-						wnpc.setCurrentHp(monsterHP);
-						wnpc.setCurrentLocation(npc.getWorldLocation());
-						wnpc.setDead(false);
-						if (locationCount.containsKey(wnpc.getCurrentLocation()))
-						{
-							wnpc.setOffset(locationCount.get(wnpc.getCurrentLocation())-1);
-							locationCount.put(wnpc.getCurrentLocation(), locationCount.get(wnpc.getCurrentLocation()) - 1);
-						}
-					}
-				}
-				else if(npc.isDead())
-				{
-					wnpc.setCurrentHp(0);
-					if(config.hideDeath())
-					{
-						wnpc.setDead(true);
-					}
-				}
+    @Subscribe
+    public void onNpcSpawned(NpcSpawned npcSpawned) {
+        final NPC npc = npcSpawned.getNpc();
+        final String npcName = npc.getName();
+        final int npcId = npc.getId();
 
-				npcLocations.put(wnpc.getNpcIndex(), wnpc.getCurrentLocation());
-			}
-		}
-	}
+        if (checkNPCName(npcName)) return;
 
-	private boolean checkNPCName(String npcName) {
-		if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase()))
-		{
-			// only care about names if we are not applying to all NPCs
-			return !this.npcShowAll;
-		}
-		return false;
-	}
 
-	@Subscribe
-	public void onConfigChanged(ConfigChanged configChanged)
-	{
-		if (Objects.equals(configChanged.getGroup(), "MonsterHP") && (Objects.equals(configChanged.getKey(), "npcShowAll") || Objects.equals(configChanged.getKey(), "npcToShowHp"))) {
-			selectedNPCs = getSelectedNPCs();
+        wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
+        npcLocations.put(npc.getIndex(), npc.getWorldLocation());
+    }
 
-			this.npcShowAll = config.npcShowAll();
-			rebuildAllNpcs();
-		}
-	}
+    @Subscribe
+    public void onNpcDespawned(NpcDespawned npcDespawned) {
+        final NPC npc = npcDespawned.getNpc();
+        final String npcName = npc.getName();
 
-	@VisibleForTesting
-	List<String> getSelectedNPCs()
-	{
-		String configNPCs = config.npcToShowHp().toLowerCase();
-		if (configNPCs.isEmpty())
-		{
-			return Collections.emptyList();
-		}
+        if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase())) {
+            return;
+        }
 
-		return Text.fromCSV(configNPCs);
-	}
+        wanderingNPCs.remove(npc.getIndex());
+        npcLocations.remove(npc.getIndex());
+    }
 
-	private void rebuildAllNpcs()
-	{
-		wanderingNPCs.clear();
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
+        if (gameStateChanged.getGameState() == GameState.LOGIN_SCREEN ||
+                gameStateChanged.getGameState() == GameState.HOPPING) {
+            wanderingNPCs.clear();
+            npcLocations.clear();
+        }
+    }
 
-		if (client.getGameState() != GameState.LOGGED_IN &&
-			client.getGameState() != GameState.LOADING)
-		{
-			// NPCs are still in the client after logging out, ignore them
-			return;
-		}
+    @Subscribe
+    public void onGameTick(GameTick event) {
+        HashMap<WorldPoint, Integer> locationCount = new HashMap<>();
+        for (WorldPoint location : npcLocations.values()) {
+            if (locationCount.containsKey(location)) {
+                locationCount.put(location, locationCount.get(location) + 1);
+            } else {
+                locationCount.put(location, 1);
+            }
+        }
+        for (NPC npc : client.getNpcs()) {
+            final String npcName = npc.getName();
+            // refactored npc name check to its own method
+            if (checkNPCName(npcName)) continue;
 
-		for (NPC npc : client.getNpcs())
-		{
-			final String npcName = npc.getName();
-			// refactored npc name check to its own method
-			if (checkNPCName(npcName)) continue;
+            final WanderingNPC wnpc = wanderingNPCs.get(npc.getIndex());
 
-			wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
-			npcLocations.put(npc.getIndex(), npc.getWorldLocation());
-		}
-	}
+            if (wnpc == null) {
+                continue;
+            }
+            double monsterHP = 0;
+            if (config.showOverlay()) {
+                monsterHP = ((double) npc.getHealthRatio() / (double) npc.getHealthScale() * 100);
+                if (!npc.isDead()) {
+                    if ((npc.getHealthRatio() / npc.getHealthScale() != 1)) {
+                        wnpc.setHealthRatio(monsterHP);
+                        wnpc.setCurrentLocation(npc.getWorldLocation());
+                        wnpc.setDead(false);
+                        if (locationCount.containsKey(wnpc.getCurrentLocation())) {
+                            wnpc.setOffset(locationCount.get(wnpc.getCurrentLocation()) - 1);
+                            locationCount.put(wnpc.getCurrentLocation(), locationCount.get(wnpc.getCurrentLocation()) - 1);
+                        }
+                    }
+                } else if (npc.isDead()) {
+                    wnpc.setHealthRatio(0);
+                    if (config.hideDeath()) {
+                        wnpc.setDead(true);
+                    }
+                }
+
+                npcLocations.put(wnpc.getNpcIndex(), wnpc.getCurrentLocation());
+            }
+        }
+    }
+
+    private boolean checkNPCName(String npcName) {
+        if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase())) {
+            // only care about names if we are not applying to all NPCs
+            return !this.npcShowAll;
+        }
+        return false;
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged configChanged) {
+        if (Objects.equals(configChanged.getGroup(), "MonsterHP") && (Objects.equals(configChanged.getKey(), "npcShowAll") || Objects.equals(configChanged.getKey(), "npcToShowHp"))) {
+            selectedNPCs = getSelectedNPCs();
+
+            this.npcShowAll = config.npcShowAll();
+            rebuildAllNpcs();
+        }
+    }
+
+    @VisibleForTesting
+    List<String> getSelectedNPCs() {
+        String configNPCs = config.npcToShowHp().toLowerCase();
+        if (configNPCs.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Text.fromCSV(configNPCs);
+    }
+
+    private void rebuildAllNpcs() {
+        wanderingNPCs.clear();
+
+        if (client.getGameState() != GameState.LOGGED_IN &&
+                client.getGameState() != GameState.LOADING) {
+            // NPCs are still in the client after logging out, ignore them
+            return;
+        }
+
+        for (NPC npc : client.getNpcs()) {
+            final String npcName = npc.getName();
+            // refactored npc name check to its own method
+            if (checkNPCName(npcName)) continue;
+
+            wanderingNPCs.putIfAbsent(npc.getIndex(), new WanderingNPC(npc));
+            npcLocations.put(npc.getIndex(), npc.getWorldLocation());
+        }
+    }
 }

--- a/src/main/java/com/monsterhp/WanderingNPC.java
+++ b/src/main/java/com/monsterhp/WanderingNPC.java
@@ -3,45 +3,55 @@ package com.monsterhp;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
 import net.runelite.api.coords.WorldPoint;
 
-public class WanderingNPC
-{
-	@Getter
-	private final int npcIndex;
+public class WanderingNPC {
+    @Getter
+    private final int npcIndex;
 
-	@Getter
-	private final String npcName;
+    @Getter
+    private final String npcName;
 
-	@Getter
-	@Setter
-	private NPC npc;
+    @Getter
+    private final int id;
+    @Getter
+    @Setter
+    private NPC npc;
 
-	@Getter
-	@Setter
-	private WorldPoint currentLocation;
+    @Getter
+    @Setter
+    private WorldPoint currentLocation;
 
-	@Getter
-	@Setter
-	private double currentHp;
+    @Getter
+    @Setter
+    private double currentHp;
 
-	@Getter
-	@Setter
-	private boolean isDead;
+    @Getter
+    @Setter
+    private double healthRatio;
 
-	@Getter
-	@Setter
-	private int offset;
+    @Getter
+    @Setter
+    private boolean isDead;
+
+    @Getter
+    @Setter
+    private int offset;
+
+    final String ATTACK_FIELD = "Attack";
 
 
-	WanderingNPC(NPC npc)
-	{
-		this.npc = npc;
-		this.npcName = npc.getName();
-		this.npcIndex = npc.getIndex();
-		this.currentLocation = npc.getWorldLocation();
-		this.currentHp = 100;
-		this.isDead = false;
-		this.offset = 0;
-	}
+    WanderingNPC(NPC npc) {
+        this.npc = npc;
+        this.id = npc.getId();
+        this.npcName = npc.getName();
+        this.npcIndex = npc.getIndex();
+        this.currentLocation = npc.getWorldLocation();
+        this.currentHp = 100;
+        this.healthRatio = 100;
+        this.isDead = false;
+        this.offset = 0;
+    }
+
 }

--- a/src/main/java/com/monsterhp/WanderingNPC.java
+++ b/src/main/java/com/monsterhp/WanderingNPC.java
@@ -39,8 +39,6 @@ public class WanderingNPC {
     @Setter
     private int offset;
 
-    final String ATTACK_FIELD = "Attack";
-
 
     WanderingNPC(NPC npc) {
         this.npc = npc;


### PR DESCRIPTION
- Changed the default height of health to 50 so it  won't be over the health bar
- Added a config option for `numericHealth` instead of showing percentage
- Added `healthRatio` to replace the `currentHealth` to the `WanderincNPC` class since those are different values 
- Created a new `getCurrentHpString(WanderingNPC)` function to handle the string for numeric health
- Edited renderTimer to add the `numericHealth` to the `WanderingNPC` instance, maybe all of this logic needs to move to plugin?

- IMPORTANT: There is currently an issue we add to the `wanderingNPCs` map adding unattackable npcs, causing many random health numbers appear, I noticed it when using `npcManager.getHealth(id)` was throwing nullpointer exceptions.\
- There is a bug in current master not adding back the hp values to monsters as they respawn

I don't know why it shows so many changes, I haven't changed that much code