### PR TITLE
Remove despawn name checks

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPPlugin.java
+++ b/src/main/java/com/monsterhp/MonsterHPPlugin.java
@@ -93,12 +93,6 @@ public class MonsterHPPlugin extends Plugin {
     @Subscribe
     public void onNpcDespawned(NpcDespawned npcDespawned) {
         final NPC npc = npcDespawned.getNpc();
-        final String npcName = npc.getName();
-
-        if (npcName == null || !selectedNPCs.contains(npcName.toLowerCase())) {
-            return;
-        }
-
         wanderingNPCs.remove(npc.getIndex());
         npcLocations.remove(npc.getIndex());
     }


### PR DESCRIPTION
When the "Show All" configuration is enabled, it is checked for NPC spawns, but not correctly checked for despawns, leading to these entries never being cleared. Anyway because calling `Map#remove()` with an entry for which no key exists is idempotent it is safe to remove any despawning NPC from these maps regardless of their name.