### PR TITLE
Yama and TOA phase 1 update

### DIFF
--- a/src/main/java/com/monsterhp/BossUtil.java
+++ b/src/main/java/com/monsterhp/BossUtil.java
@@ -40,8 +40,11 @@ public class BossUtil {
     );
 
     public static boolean isNpcBossFromTOA(NPC npc) {
+        int id = npc.getId();
         String name = npc.getName();
-        return name != null && TOA_BOSS_NAMES.contains(name);
+        boolean isWardenP1 = (id == TOA_WARDEN_TUMEKEN_PHASE1 || id == TOA_WARDEN_ELIDINIS_PHASE1);
+
+        return name != null && TOA_BOSS_NAMES.contains(name) && !isWardenP1;
     }
 
     public static boolean isNpcBossFromCOX(NPC npc) {return COX_BOSS_IDS.contains(npc.getId());}

--- a/src/main/java/com/monsterhp/MonsterHPOverlay.java
+++ b/src/main/java/com/monsterhp/MonsterHPOverlay.java
@@ -143,7 +143,7 @@ public class MonsterHPOverlay extends Overlay {
         }
 
         if (config.useGradientHP()) {
-            if (maxHealth != null) {
+            if (maxHealth != null && maxHealth > 1) {
                 int curNumericHealth = (int) Math.floor((wNpcHealthRatio / 100) * maxHealth);
                 timerColor = getGradientHpColor(curNumericHealth, maxHealth);
             } else { // Try percentage based gradient hp - happens if npcManager can't get numeric max health.

--- a/src/main/java/com/monsterhp/MonsterHPPlugin.java
+++ b/src/main/java/com/monsterhp/MonsterHPPlugin.java
@@ -190,7 +190,10 @@ public class MonsterHPPlugin extends Plugin {
             final int curHp = client.getVarbitValue(HPBAR_HUD_HP);
             final int maxHp = client.getVarbitValue(HPBAR_HUD_BASEHP);
             if (maxHp > 0 && curHp >= 0) {
-                monsterHp = 100.0 * curHp / maxHp;
+                double hpVarbitRatio = 100.0 * curHp / maxHp;
+                if (hpVarbitRatio > 0) {
+                    monsterHp = hpVarbitRatio;
+                }
             } else {
                 // If we can't get data just don't update.
                 return;


### PR DESCRIPTION
Added a varbit ratio check.

Added a 'warden phase 1' check for TOA to prevent hpbar_hud varbits confusing obelisk with the wardens health.

Should fix #53 #54 #55 