### PR TITLE
[Fix] Prevent numeric 100 hp turning into percents

### DIFF
--- a/src/main/java/com/monsterhp/MonsterHPOverlay.java
+++ b/src/main/java/com/monsterhp/MonsterHPOverlay.java
@@ -70,13 +70,14 @@ public class MonsterHPOverlay extends Overlay {
     private String getCurrentHpString(WanderingNPC wnpc) {
         boolean showNumericHealth = config.numericAllHealth() || wnpc.getIsTypeNumeric() == 1;
         NPC npc = wnpc.getNpc();
+        double healthRatioValue = wnpc.getHealthRatio();
 
         // Numeric
         if (showNumericHealth) {
-            String healthRatio = format.format(wnpc.getHealthRatio());
+            String healthRatio = format.format(healthRatioValue);
 
-            // getCurrentHp() returns numeric hp value if set, default is WanderingNpc value 100
-            boolean usePercentage = wnpc.getCurrentHp() == 100 && wnpc.getHealthRatio() < 100.0;
+            // getCurrentHp() returns numeric hp value if set, default is WanderingNpc value -1
+            boolean usePercentage = wnpc.getCurrentHp() == -1 && healthRatioValue < 100.0;
 
             if (BossUtil.isNpcBoss(npc)) {
                 // Defaults to percentage if numeric fails
@@ -90,9 +91,9 @@ public class MonsterHPOverlay extends Overlay {
 
         // Percentage
         switch (config.decimalHp()) {
-            case 1:  return String.valueOf(oneDecimalFormat.format(wnpc.getHealthRatio()));
-            case 2:  return String.valueOf(twoDecimalFormat.format(wnpc.getHealthRatio()));
-            default: return String.valueOf((wnpc.getHealthRatio() >= 1) ? format.format(wnpc.getHealthRatio()) : twoDecimalFormat.format(wnpc.getHealthRatio()));
+            case 1:  return String.valueOf(oneDecimalFormat.format(healthRatioValue));
+            case 2:  return String.valueOf(twoDecimalFormat.format(healthRatioValue));
+            default: return String.valueOf((healthRatioValue >= 1) ? format.format(healthRatioValue) : twoDecimalFormat.format(healthRatioValue));
         }
     }
 
@@ -130,7 +131,7 @@ public class MonsterHPOverlay extends Overlay {
         boolean isUsingNumeric = config.numericAllHealth() || wnpc.getIsTypeNumeric() == 1;
         if (isUsingNumeric && maxHealth != null) {
             // Use the current health ratio and round it according to monsters max hp
-            double numericHealth = (int) Math.floor((wNpcHealthRatio / 100) * maxHealth);
+            double numericHealth = (int) Math.round((wNpcHealthRatio / 100) * maxHealth);
             wnpc.setCurrentHp(numericHealth);
         }
 

--- a/src/main/java/com/monsterhp/WanderingNPC.java
+++ b/src/main/java/com/monsterhp/WanderingNPC.java
@@ -56,7 +56,7 @@ public class WanderingNPC {
         this.npcName = npc.getName();
         this.npcIndex = npc.getIndex();
         this.currentLocation = npc.getWorldLocation();
-        this.currentHp = 100;
+        this.currentHp = -1;
         this.healthRatio = 100;
         this.healthScale = npc.getHealthScale();
         this.isDead = false;


### PR DESCRIPTION
Since the plugin checked if monster had exactly 100 hp as being "default", it let to the issue that made monsters hp jump e.g. 120 -> 40 -> 90. Now it's displayed correctly and default hp value was changed to -1 for consistency with RuneLite's `Actor` class.

<img width="242" height="345" alt="image" src="https://github.com/user-attachments/assets/04c50492-3bcb-4f5a-b952-aaa094fd6daf" />
